### PR TITLE
Fixed some compute tools and workflows

### DIFF
--- a/src/backend/microservices/compute/src/main/java/org/phyloviz/pwp/compute/repository/metadata/templates/workflow_template/documents/arguments/WorkflowTemplateArgumentType.java
+++ b/src/backend/microservices/compute/src/main/java/org/phyloviz/pwp/compute/repository/metadata/templates/workflow_template/documents/arguments/WorkflowTemplateArgumentType.java
@@ -4,6 +4,7 @@ public enum WorkflowTemplateArgumentType {
     OBJECTID,
     UUID,
     STRING,
+    NUMBER,
     DATASETID,
     DISTANCEMATRIXID,
     TREEID,

--- a/src/backend/microservices/compute/src/main/java/org/phyloviz/pwp/compute/service/ComputeServiceImpl.java
+++ b/src/backend/microservices/compute/src/main/java/org/phyloviz/pwp/compute/service/ComputeServiceImpl.java
@@ -25,11 +25,7 @@ import org.phyloviz.pwp.compute.service.flowviz.models.get_workflow.AirflowWorkf
 import org.phyloviz.pwp.compute.service.flowviz.models.get_workflow.GetWorkflowResponse;
 import org.phyloviz.pwp.compute.service.flowviz.models.tool.Tool;
 import org.phyloviz.pwp.compute.service.flowviz.models.workflow.Workflow;
-import org.phyloviz.pwp.shared.repository.metadata.dataset.DatasetRepository;
-import org.phyloviz.pwp.shared.repository.metadata.distance_matrix.DistanceMatrixMetadataRepository;
 import org.phyloviz.pwp.shared.repository.metadata.project.ProjectRepository;
-import org.phyloviz.pwp.shared.repository.metadata.tree.TreeMetadataRepository;
-import org.phyloviz.pwp.shared.repository.metadata.tree_view.TreeViewMetadataRepository;
 import org.phyloviz.pwp.shared.service.exceptions.ProjectNotFoundException;
 import org.phyloviz.pwp.shared.utils.UUIDUtils;
 import org.springframework.stereotype.Service;
@@ -46,11 +42,6 @@ import java.util.Map;
 public class ComputeServiceImpl implements ComputeService {
 
     private final ProjectRepository projectRepository;
-    private final DatasetRepository datasetRepository;
-
-    private final DistanceMatrixMetadataRepository distanceMatrixMetadataRepository;
-    private final TreeMetadataRepository treeMetadataRepository;
-    private final TreeViewMetadataRepository treeViewMetadataRepository;
 
     private final WorkflowTemplateRepository workflowTemplateRepository;
     private final WorkflowInstanceRepository workflowInstanceRepository;
@@ -224,6 +215,13 @@ public class ComputeServiceImpl implements ComputeService {
         return new CreateWorkflowOutput(workflowId);
     }
 
+    /**
+     * Validates that the arguments received in the request are valid for the workflow template. Verifies that all
+     * required arguments are present and that the types are correct.
+     *
+     * @param createWorkflowArguments the arguments defined in the workflow template
+     * @param properties              the arguments received in the request
+     */
     private void validateCreateWorkflowArguments(Map<String, WorkflowTemplateArgumentProperties> createWorkflowArguments,
                                                  Map<String, String> properties) {
         properties.keySet().stream().filter(key -> !createWorkflowArguments.containsKey(key)).findAny()
@@ -241,6 +239,7 @@ public class ComputeServiceImpl implements ComputeService {
                         validateUUIDArgument(properties.get(argumentName), argumentName);
                 case STRING -> validateStringArgument(properties.get(argumentName), argumentName,
                         argumentProperties.getAllowedValues());
+                case NUMBER -> validateNumberArgument(properties.get(argumentName), argumentName);
             }
         });
     }
@@ -260,5 +259,13 @@ public class ComputeServiceImpl implements ComputeService {
             throw new InvalidWorkflowException(String.format(
                     "Invalid argument: '%s'. Must be one of the allowed values: %s", argumentName, allowedValues)
             );
+    }
+
+    private void validateNumberArgument(String argument, String argumentName) {
+        try {
+            Double.parseDouble(argument);
+        } catch (NumberFormatException e) {
+            throw new InvalidWorkflowException(String.format("Invalid argument: '%s'. Must be a number.", argumentName));
+        }
     }
 }

--- a/src/backend/microservices/compute/src/main/java/org/phyloviz/pwp/compute/service/ComputeServiceImpl.java
+++ b/src/backend/microservices/compute/src/main/java/org/phyloviz/pwp/compute/service/ComputeServiceImpl.java
@@ -16,14 +16,9 @@ import org.phyloviz.pwp.compute.repository.metadata.templates.workflow_template.
 import org.phyloviz.pwp.compute.repository.metadata.templates.workflow_template.documents.arguments.WorkflowTemplateArgumentProperties;
 import org.phyloviz.pwp.compute.service.dtos.create_workflow.CreateWorkflowOutput;
 import org.phyloviz.pwp.compute.service.dtos.get_workflow.GetWorkflowStatusOutput;
-import org.phyloviz.pwp.compute.service.exceptions.DatasetDoesNotExistException;
-import org.phyloviz.pwp.compute.service.exceptions.DistanceMatrixDoesNotExistException;
 import org.phyloviz.pwp.compute.service.exceptions.InvalidWorkflowException;
 import org.phyloviz.pwp.compute.service.exceptions.TemplateNotFound;
-import org.phyloviz.pwp.compute.service.exceptions.TreeDoesNotExistException;
-import org.phyloviz.pwp.compute.service.exceptions.TreeViewDoesNotExistException;
 import org.phyloviz.pwp.compute.service.exceptions.WorkflowInstanceNotFoundException;
-import org.phyloviz.pwp.compute.service.exceptions.WorkflowTemplateConfigurationException;
 import org.phyloviz.pwp.compute.service.flowviz.FLOWViZClient;
 import org.phyloviz.pwp.compute.service.flowviz.exceptions.UnexpectedResponseException;
 import org.phyloviz.pwp.compute.service.flowviz.models.get_workflow.AirflowWorkflowStatus;
@@ -31,7 +26,6 @@ import org.phyloviz.pwp.compute.service.flowviz.models.get_workflow.GetWorkflowR
 import org.phyloviz.pwp.compute.service.flowviz.models.tool.Tool;
 import org.phyloviz.pwp.compute.service.flowviz.models.workflow.Workflow;
 import org.phyloviz.pwp.shared.repository.metadata.dataset.DatasetRepository;
-import org.phyloviz.pwp.shared.repository.metadata.dataset.documents.Dataset;
 import org.phyloviz.pwp.shared.repository.metadata.distance_matrix.DistanceMatrixMetadataRepository;
 import org.phyloviz.pwp.shared.repository.metadata.project.ProjectRepository;
 import org.phyloviz.pwp.shared.repository.metadata.tree.TreeMetadataRepository;
@@ -167,7 +161,7 @@ public class ComputeServiceImpl implements ComputeService {
                 .findByName(workflowType)
                 .orElseThrow(() -> new InvalidWorkflowException("Workflow type not found"));
 
-        validateCreateWorkflowArguments(workflowTemplate.getArguments(), properties, projectId);
+        validateCreateWorkflowArguments(workflowTemplate.getArguments(), properties);
 
         Map<String, Object> workflowInstanceData = new HashMap<>(properties);
         workflowInstanceData.put("projectId", projectId);
@@ -231,9 +225,7 @@ public class ComputeServiceImpl implements ComputeService {
     }
 
     private void validateCreateWorkflowArguments(Map<String, WorkflowTemplateArgumentProperties> createWorkflowArguments,
-                                                 Map<String, String> properties, String projectId) {
-        Map<String, String> specialArguments = new HashMap<>();
-
+                                                 Map<String, String> properties) {
         properties.keySet().stream().filter(key -> !createWorkflowArguments.containsKey(key)).findAny()
                 .ifPresent(key -> {
                     throw new InvalidWorkflowException(String.format("Unknown argument: '%s'", key));
@@ -244,16 +236,11 @@ public class ComputeServiceImpl implements ComputeService {
                 throw new InvalidWorkflowException(String.format("Missing argument: '%s'", argumentName));
 
             switch (argumentProperties.getType()) {
-                case OBJECTID -> validateObjectIdArgument(properties.get(argumentName), argumentName);
-                case UUID -> validateUUIDArgument(properties.get(argumentName), argumentName);
+                case OBJECTID, DATASETID -> validateObjectIdArgument(properties.get(argumentName), argumentName);
+                case UUID, DISTANCEMATRIXID, TREEID, TREEVIEWID ->
+                        validateUUIDArgument(properties.get(argumentName), argumentName);
                 case STRING -> validateStringArgument(properties.get(argumentName), argumentName,
                         argumentProperties.getAllowedValues());
-                case DATASETID -> validateDatasetIdArgument(properties, projectId, specialArguments, argumentName,
-                        argumentProperties);
-                case DISTANCEMATRIXID -> validateDistanceMatrixIdArgument(properties, projectId, specialArguments,
-                        argumentName);
-                case TREEID -> validateTreeIdArgument(properties, projectId, specialArguments, argumentName);
-                case TREEVIEWID -> validateTreeViewIdArgument(properties, projectId, specialArguments, argumentName);
             }
         });
     }
@@ -273,75 +260,5 @@ public class ComputeServiceImpl implements ComputeService {
             throw new InvalidWorkflowException(String.format(
                     "Invalid argument: '%s'. Must be one of the allowed values: %s", argumentName, allowedValues)
             );
-    }
-
-    private void validateDatasetIdArgument(Map<String, String> properties, String projectId,
-                                           Map<String, String> specialArguments, String argumentName,
-                                           WorkflowTemplateArgumentProperties argumentProperties) {
-        String datasetId = properties.get(argumentName);
-        validateObjectIdArgument(datasetId, argumentName);
-
-        specialArguments.put("datasetId", datasetId);
-
-        Dataset dataset = datasetRepository.findByProjectIdAndId(projectId, datasetId)
-                .orElseThrow(DatasetDoesNotExistException::new);
-
-        if (argumentProperties.getObtainExtra() == null)
-            return;
-
-        argumentProperties.getObtainExtra().forEach((extraArgumentName, extraArgumentProperties) -> {
-            switch (extraArgumentProperties.getType()) {
-                case TYPINGDATAID -> properties.put(extraArgumentName, dataset.getTypingDataId());
-                case ISOLATEDATAID -> properties.put(extraArgumentName, dataset.getIsolateDataId());
-            }
-        });
-    }
-
-    private void validateDistanceMatrixIdArgument(Map<String, String> properties, String projectId,
-                                                  Map<String, String> specialArguments, String argumentName) {
-        String distanceMatrixId = properties.get(argumentName);
-        validateUUIDArgument(distanceMatrixId, argumentName);
-
-        if (!specialArguments.containsKey("datasetId"))
-            throw new WorkflowTemplateConfigurationException("Missing datasetId argument before distanceMatrixId argument.");
-
-        String datasetId = specialArguments.get("datasetId");
-
-        if (!distanceMatrixMetadataRepository.existsByProjectIdAndDatasetIdAndDistanceMatrixId(projectId, datasetId, distanceMatrixId))
-            throw new DistanceMatrixDoesNotExistException();
-
-        specialArguments.put("distanceMatrixId", distanceMatrixId);
-    }
-
-    private void validateTreeIdArgument(Map<String, String> properties, String projectId,
-                                        Map<String, String> specialArguments, String argumentName) {
-        String treeId = properties.get(argumentName);
-        validateUUIDArgument(treeId, argumentName);
-
-        if (!specialArguments.containsKey("datasetId"))
-            throw new WorkflowTemplateConfigurationException("Missing datasetId argument before treeId argument.");
-
-        String datasetId = specialArguments.get("datasetId");
-
-        if (!treeMetadataRepository.existsByProjectIdAndDatasetIdAndTreeId(projectId, datasetId, treeId))
-            throw new TreeDoesNotExistException();
-
-        specialArguments.put("treeId", treeId);
-    }
-
-    private void validateTreeViewIdArgument(Map<String, String> properties, String projectId,
-                                            Map<String, String> specialArguments, String argumentName) {
-        String treeViewId = properties.get(argumentName);
-        validateUUIDArgument(treeViewId, argumentName);
-
-        if (!specialArguments.containsKey("datasetId"))
-            throw new WorkflowTemplateConfigurationException("Missing datasetId argument before treeViewId argument.");
-
-        String datasetId = specialArguments.get("datasetId");
-
-        if (!treeViewMetadataRepository.existsByProjectIdAndDatasetIdAndTreeViewId(projectId, datasetId, treeViewId))
-            throw new TreeViewDoesNotExistException();
-
-        specialArguments.put("treeViewId", treeViewId);
     }
 }

--- a/src/backend/microservices/file-transfer/src/main/java/org/phyloviz/pwp/file_transfer/http/controllers/FileTransferController.java
+++ b/src/backend/microservices/file-transfer/src/main/java/org/phyloviz/pwp/file_transfer/http/controllers/FileTransferController.java
@@ -36,9 +36,12 @@ public class FileTransferController {
     public ResponseEntity<UploadTypingDataOutputModel> uploadTypingData(
             @PathVariable String projectId,
             @RequestPart MultipartFile file,
+            @RequestPart String type,
             User user
     ) {
-        UploadTypingDataOutput uploadTypingDataOutput = fileTransferService.uploadTypingData(projectId, file, user.getId());
+        UploadTypingDataOutput uploadTypingDataOutput = fileTransferService.uploadTypingData(
+                projectId, file, type, user.getId()
+        );
 
         URI location = ServletUriComponentsBuilder.fromCurrentRequest()
                 .path("/{typingDataId}")

--- a/src/backend/microservices/file-transfer/src/main/java/org/phyloviz/pwp/file_transfer/service/FileTransferService.java
+++ b/src/backend/microservices/file-transfer/src/main/java/org/phyloviz/pwp/file_transfer/service/FileTransferService.java
@@ -11,10 +11,11 @@ public interface FileTransferService {
      *
      * @param projectId the name of the project to which the typing data will be uploaded
      * @param file      the file to be uploaded
+     * @param type      the type of the typing data
      * @param userId    the if of the user that is uploading the typing data
      * @return information about the uploaded typing data
      */
-    UploadTypingDataOutput uploadTypingData(String projectId, MultipartFile file, String userId);
+    UploadTypingDataOutput uploadTypingData(String projectId, MultipartFile file, String type, String userId);
 
     /**
      * Uploads an isolate data.

--- a/src/backend/microservices/file-transfer/src/main/java/org/phyloviz/pwp/file_transfer/service/FileTransferServiceImpl.java
+++ b/src/backend/microservices/file-transfer/src/main/java/org/phyloviz/pwp/file_transfer/service/FileTransferServiceImpl.java
@@ -45,7 +45,7 @@ public class FileTransferServiceImpl implements FileTransferService {
     private IsolateDataDataRepositoryId uploadIsolateDataRepositoryId;
 
     @Override
-    public UploadTypingDataOutput uploadTypingData(String projectId, MultipartFile file, String userId) {
+    public UploadTypingDataOutput uploadTypingData(String projectId, MultipartFile file, String type, String userId) {
         if (!projectRepository.existsByIdAndOwnerId(projectId, userId))
             throw new ProjectNotFoundException();
 
@@ -58,6 +58,7 @@ public class FileTransferServiceImpl implements FileTransferService {
         TypingDataMetadata typingDataMetadata = new TypingDataMetadata(
                 projectId,
                 typingDataId,
+                type,
                 file.getOriginalFilename(),
                 uploadTypingDataRepositoryId,
                 typingDataDataRepositorySpecificData

--- a/src/backend/microservices/shared/src/main/java/org/phyloviz/pwp/shared/http/pipeline/advice/exception/handlers/SharedExceptionHandler.java
+++ b/src/backend/microservices/shared/src/main/java/org/phyloviz/pwp/shared/http/pipeline/advice/exception/handlers/SharedExceptionHandler.java
@@ -15,6 +15,7 @@ import org.phyloviz.pwp.shared.service.exceptions.UnauthorizedException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.zalando.problem.Problem;
 import org.zalando.problem.Status;
 
@@ -83,6 +84,22 @@ public class SharedExceptionHandler {
 
         return Problem.builder()
                 .withTitle(title)
+                .withStatus(Status.BAD_REQUEST)
+                .build();
+    }
+
+    /**
+     * Handles MissingServletRequestPartException.
+     *
+     * @param ex the exception
+     * @return a Problem with the status BAD_REQUEST
+     */
+    @ExceptionHandler(value = {MissingServletRequestPartException.class})
+    public Problem handleMissingServletRequestPartExceptions(
+            MissingServletRequestPartException ex
+    ) {
+        return Problem.builder()
+                .withTitle(String.format("Missing request part '%s'", ex.getRequestPartName()))
                 .withStatus(Status.BAD_REQUEST)
                 .build();
     }

--- a/src/backend/microservices/shared/src/main/java/org/phyloviz/pwp/shared/repository/metadata/tree_view/documents/TreeViewMetadata.java
+++ b/src/backend/microservices/shared/src/main/java/org/phyloviz/pwp/shared/repository/metadata/tree_view/documents/TreeViewMetadata.java
@@ -22,6 +22,11 @@ public class TreeViewMetadata {
     private String treeViewId;
     private String name;
     private String layout;
+    /*private Filters filters = { "nodeSizeByIsolateNumber": true,
+            "showNodeLabels": true,
+            "showLinkWeightLabels": true,
+            "typingDataColumns": [],
+            "isolateDataColumns": ["country"];*/
     private TreeViewSource source;
     private TreeViewDataRepositoryId repositoryId;
     private TreeViewDataRepositorySpecificData repositorySpecificData;

--- a/src/backend/microservices/shared/src/main/java/org/phyloviz/pwp/shared/repository/metadata/typing_data/documents/TypingDataMetadata.java
+++ b/src/backend/microservices/shared/src/main/java/org/phyloviz/pwp/shared/repository/metadata/typing_data/documents/TypingDataMetadata.java
@@ -26,10 +26,11 @@ public class TypingDataMetadata {
     private TypingDataDataRepositoryId repositoryId;
     private TypingDataDataRepositorySpecificData repositorySpecificData;
 
-    public TypingDataMetadata(String projectId, String typingDataId, String name, TypingDataDataRepositoryId repositoryId,
+    public TypingDataMetadata(String projectId, String typingDataId, String type, String name, TypingDataDataRepositoryId repositoryId,
                               TypingDataDataRepositorySpecificData repositorySpecificData) {
         this.projectId = projectId;
         this.typingDataId = typingDataId;
+        this.type = type;
         this.name = name;
         this.repositoryId = repositoryId;
         this.repositorySpecificData = repositorySpecificData;

--- a/src/backend/microservices/shared/src/main/java/org/phyloviz/pwp/shared/repository/metadata/typing_data/documents/TypingDataMetadata.java
+++ b/src/backend/microservices/shared/src/main/java/org/phyloviz/pwp/shared/repository/metadata/typing_data/documents/TypingDataMetadata.java
@@ -21,6 +21,7 @@ public class TypingDataMetadata {
 
     private String projectId;
     private String typingDataId;
+    private String type;
     private String name;
     private TypingDataDataRepositoryId repositoryId;
     private TypingDataDataRepositorySpecificData repositorySpecificData;

--- a/src/backend/microservices/shared/src/main/java/org/phyloviz/pwp/shared/repository/metadata/typing_data/documents/converters/TypingDataMetadataDeserializer.java
+++ b/src/backend/microservices/shared/src/main/java/org/phyloviz/pwp/shared/repository/metadata/typing_data/documents/converters/TypingDataMetadataDeserializer.java
@@ -37,6 +37,7 @@ public class TypingDataMetadataDeserializer implements Converter<Document, Typin
                     document.getObjectId("_id").toString(),
                     document.getString("projectId"),
                     document.getString("typingDataId"),
+                    document.getString("type"),
                     document.getString("name"),
                     repositoryId,
                     repositorySpecificData

--- a/src/backend/microservices/shared/src/main/java/org/phyloviz/pwp/shared/repository/metadata/typing_data/documents/converters/TypingDataMetadataSerializer.java
+++ b/src/backend/microservices/shared/src/main/java/org/phyloviz/pwp/shared/repository/metadata/typing_data/documents/converters/TypingDataMetadataSerializer.java
@@ -24,6 +24,7 @@ public class TypingDataMetadataSerializer implements Converter<TypingDataMetadat
                     Map.of(
                             "projectId", typingDataMetadata.getProjectId(),
                             "typingDataId", typingDataMetadata.getTypingDataId(),
+                            "type", typingDataMetadata.getType(),
                             "name", typingDataMetadata.getName(),
                             "repositoryId", typingDataMetadata.getRepositoryId().name().toLowerCase(),
                             "repositorySpecificData", Objects.requireNonNull(

--- a/src/backend/mongo/workflow-templates.json
+++ b/src/backend/mongo/workflow-templates.json
@@ -40,7 +40,7 @@
         "taskId": "upload",
         "tool": "uploader",
         "action": {
-          "command": " --file-path=/phyloviz-web-platform/distance_matrix.txt --project-id=${projectId} --dataset-id=${datasetId} --workflow-id=${workflowId} --resource-type=distance-matrix"
+          "command": " --file-path=/phyloviz-web-platform/distance_matrix.txt --project-id=${projectId} --dataset-id=${datasetId} --workflow-id=${workflowId} --resource-type=distance-matrix --source-type=function --function=${function}"
         }
       }
     ]
@@ -97,7 +97,7 @@
         "taskId": "upload",
         "tool": "uploader",
         "action": {
-          "command": " --file-path=/phyloviz-web-platform/tree.txt --project-id=${projectId} --dataset-id=${datasetId} --workflow-id=${workflowId} --resource-type=tree --source-type=algorithm-distance-matrix"
+          "command": " --file-path=/phyloviz-web-platform/tree.txt --project-id=${projectId} --dataset-id=${datasetId} --workflow-id=${workflowId} --resource-type=tree --source-type=algorithm-distance-matrix --algorithm=${algorithm} --distance-matrix-id=${distanceMatrixId} --parameters={}"
         }
       }
     ]
@@ -170,6 +170,13 @@
       },
       "treeId": {
         "type": "treeId"
+      },
+      "layout": {
+        "type": "string",
+        "allowed-values": [
+          "force-directed",
+          "radial"
+        ]
       }
     },
     "tasks": [
@@ -177,7 +184,7 @@
         "taskId": "treeViewCompute",
         "tool": "compute_tree_view",
         "action": {
-          "command": "--project-id=${projectId} --dataset-id=${datasetId} --tree-id=${treeId} --workflow-id=${workflowId}"
+          "command": "--project-id=${projectId} --dataset-id=${datasetId} --tree-id=${treeId} --workflow-id=${workflowId} --layout=${layout}"
         }
       }
     ]

--- a/src/backend/mongo/workflow-templates.json
+++ b/src/backend/mongo/workflow-templates.json
@@ -4,18 +4,14 @@
     "description": "Compute Distance Matrix Workflow",
     "arguments": {
       "datasetId": {
-        "type": "datasetId",
-        "obtain-extra": {
-          "typingDataId": {
-            "type": "typingDataId"
-          }
-        }
+        "type": "datasetId"
       },
       "function": {
         "type": "string",
         "allowed-values": [
           "hamming",
-          "levenshtein"
+          "grapetree",
+          "kimura"
         ]
       }
     },
@@ -24,7 +20,7 @@
         "taskId": "download",
         "tool": "downloader",
         "action": {
-          "command": "--resource-id=${typingDataId} --resource-type=typing-data --out=/phyloviz-web-platform/typing_dataset.txt"
+          "command": "--project-id=${projectId} --dataset-id=${datasetId} --resource-type=typing-data --workflow-id=${workflowId} --out=/phyloviz-web-platform/typing_dataset.txt"
         },
         "children": [
           "distanceCalculation"
@@ -81,7 +77,7 @@
         "taskId": "download",
         "tool": "downloader",
         "action": {
-          "command": "--resource-id=${distanceMatrixId} --resource-type=distance-matrix --out=/phyloviz-web-platform/distance_matrix.txt"
+          "command": "--project-id=${projectId} --dataset-id=${datasetId} --resource-id=${distanceMatrixId} --resource-type=distance-matrix  --workflow-id=${workflowId} --out=/phyloviz-web-platform/distance_matrix.txt"
         },
         "children": [
           "treeCalculation"
@@ -101,7 +97,7 @@
         "taskId": "upload",
         "tool": "uploader",
         "action": {
-          "command": " --file-path=/phyloviz-web-platform/tree.txt --project-id=${projectId} --dataset-id=${datasetId} --workflow-id=${workflowId} --resource-type=tree"
+          "command": " --file-path=/phyloviz-web-platform/tree.txt --project-id=${projectId} --dataset-id=${datasetId} --workflow-id=${workflowId} --resource-type=tree --source-type=algorithm-distance-matrix"
         }
       }
     ]
@@ -111,12 +107,7 @@
     "description": "Index Typing Data Workflow",
     "arguments": {
       "datasetId": {
-        "type": "datasetId",
-        "obtain-extra": {
-          "typingDataId": {
-            "type": "typingDataId"
-          }
-        }
+        "type": "datasetId"
       }
     },
     "tasks": [
@@ -124,7 +115,7 @@
         "taskId": "download",
         "tool": "downloader",
         "action": {
-          "command": "--resource-id=${typingDataId} --resource-type=typing-data --out=/phyloviz-web-platform/typing_dataset.txt"
+          "command": "--project-id=${projectId} --dataset-id=${datasetId} --resource-type=typing-data  --workflow-id=${workflowId} --out=/phyloviz-web-platform/typing_dataset.txt"
         },
         "children": [
           "typingDataIndexing"
@@ -155,7 +146,7 @@
         "taskId": "download",
         "tool": "downloader",
         "action": {
-          "command": "--resource-id=${treeId} --resource-type=tree --out=/phyloviz-web-platform/tree.txt"
+          "command": "--project-id=${projectId} --dataset-id=${datasetId} --resource-id=${treeId} --resource-type=tree --workflow-id=${workflowId} --out=/phyloviz-web-platform/tree.txt"
         },
         "children": [
           "treeIndexing"

--- a/src/backend/tools/downloader/downloader.py
+++ b/src/backend/tools/downloader/downloader.py
@@ -5,6 +5,7 @@ import os
 from botocore.exceptions import NoCredentialsError, ClientError
 from pymongo import MongoClient
 from urllib.parse import urlparse
+from bson.objectid import ObjectId
 
 resource_type_collection_map = {
     "tree": "trees",
@@ -20,6 +21,12 @@ resource_type_id_attr_map = {
     "isolate-data": "isolateDataId",
 }
 
+# Connect to MongoDB
+mongo_uri = os.environ['MONGO_URI']
+client = MongoClient(mongo_uri)
+db = client['phyloviz-web-platform']
+workflows_collection = db['workflow-instances']
+datasets_collection = db['datasets']
 
 def get_collection_from_resource_type(resource_type):
     return resource_type_collection_map[resource_type]
@@ -29,19 +36,73 @@ def get_resource_id_attr_from_resource_type(resource_type):
     return resource_type_id_attr_map[resource_type]
 
 
-def download_s3_object(resource_id, resource_type, out):
+def download_s3_object(project_id, dataset_id, resource_id, resource_type, out, workflow_id):
     print(f'Downloading {resource_id} from {resource_type} to {out}...')
-    mongo_uri = os.environ['MONGO_URI']
-    mongo_client = MongoClient(mongo_uri)
-    db = mongo_client['phyloviz-web-platform']
     resource_type_collection = db[get_collection_from_resource_type(resource_type)]
 
-    resource = resource_type_collection.find_one(
-        {get_resource_id_attr_from_resource_type(resource_type): resource_id, 'repositoryId': 's3'})
+    if resource_type == 'tree' or resource_type == 'distance-matrix':
+        # Obtain the resource metadata with a repositoryId 's3'
+            resource = resource_type_collection.find_one(
+                {
+                'project_Id': project_id,
+                'datasetId': dataset_id,
+                get_resource_id_attr_from_resource_type(resource_type): resource_id,
+                'repositoryId': 's3'
+                }
+            )
+    elif resource_type == 'typing-data' or resource_type == 'isolate-data':
+        dataset = datasets_collection.find_one(
+            {
+            'project_Id': project_id,
+            'datasetId': dataset_id
+            }
+        )
 
+        # Obtain the typing data or isolate data id from the dataset
+        if resource_type == 'typing-data':
+            resource_id = dataset['typingDataId']
+        elif resource_type == 'isolate-data':
+            resource_id = dataset['isolateDataId']
+
+        # Obtain the resource metadata with a repositoryId 's3'
+        resource = resource_type_collection.find_one(
+            {
+            'project_Id': project_id,
+            get_resource_id_attr_from_resource_type(resource_type): resource_id,
+            'repositoryId': 's3'
+            }
+        )
+
+        if resource_type == 'typing-data':
+            workflows_collection.update_one(
+                {
+                    '_id': workflow_id
+                },
+                {
+                    '$set': {
+                        'data.typingDataId': dataset['typingDataId'],
+                        'data.typingDataType': resource['type']
+                    }
+                }
+            )
+        else:
+            workflows_collection.update_one(
+                {
+                    'workflowInstanceId': workflow_id
+                },
+                {
+                    '$set': {
+                        'data.isolateDataId': dataset['isolateDataId']
+                    }
+                }
+            )
+    else:
+        print(f'Error: Invalid resource type: {resource_type}')
+        return
+
+    # Obtain the S3 URL from the repositorySpecificData
     s3_url = resource['repositorySpecificData']['url']
 
-    # Get the S3 URL from the resourceType collection
     # Parse the S3 URL
     parsed_url = urlparse(s3_url)
     path = parsed_url.path.lstrip('/')
@@ -49,6 +110,7 @@ def download_s3_object(resource_id, resource_type, out):
     object_key = path.lstrip(f'{bucket_name}')
 
     print("Retrieving S3 object from bucket: " + bucket_name + " and key: " + object_key)
+
     # Obtain endpoint url from ~/.aws/config
     # Read the custom endpoint URL from the config file
     config = configparser.ConfigParser()
@@ -72,9 +134,12 @@ if __name__ == '__main__':
     # Make it so the script always starts with download  argument
     parser = argparse.ArgumentParser(description='Download an S3 object to a specific folder')
     parser.add_argument('--out', help='The output file path', required=True)
-    parser.add_argument(
-        '--resource-id', help='The ID of the resource', required=True)
+    parser.add_argument('--project-id', help='The project id', required=True)
+    parser.add_argument('--dataset-id', help='The dataset id', required=True)
+    parser.add_argument('--resource-id', help='The optional ID of the resource', required=False)
     parser.add_argument('--resource-type', help='The resource type', required=True)
+    parser.add_argument('--workflow-id', help='The workflow ID to update in MongoDB', required=True)
 
     args = parser.parse_args()
-    download_s3_object(args.resource_id, args.resource_type, args.out)
+    download_s3_object(args.project_id, args.dataset_id, args.resource_id, args.resource_type, args.out,
+                        args.workflow_id)

--- a/src/backend/tools/uploader/uploader.py
+++ b/src/backend/tools/uploader/uploader.py
@@ -135,6 +135,13 @@ def get_collection_from_resource_type(resource_type):
 
 def upload_file_to_s3(file_path, project_id, dataset_id, workflow_id, resource_id, resource_type, source_type,
                         algorithm, distance_matrix_id, parameters, function):
+    print(f"Project ID: {project_id}")
+    print(f"Dataset ID: {dataset_id}")
+    print(f"Resource ID: {resource_id}")
+    print(f"Resource Type: {resource_type}")
+    print(f"File path: {file_path}")
+    print(f"Workflow ID: {workflow_id}")
+
     # Generate a unique resource_id if not provided
     if not resource_id:
         resource_id = str(uuid.uuid4())

--- a/src/backend/tools/uploader/uploader.py
+++ b/src/backend/tools/uploader/uploader.py
@@ -25,26 +25,43 @@ workflows_collection = db['workflow-instances']
 datasets_collection = db['datasets']
 
 
-def tree_handler(s3_output_path, project_id, dataset_id, tree_id, workflow_id, source_type):
+def tree_handler(s3_output_path, project_id, dataset_id, workflow_id, tree_id, source_type, algorithm,
+                    distance_matrix_id, parameters):
     tree_collection = db['trees']
 
-    workflows_collection.update_one(
-        {'_id': ObjectId(workflow_id)},
-        {'$set': {
-            'data.treeId': tree_id
-        }})
+    if source_type == 'algorithm_distance_matrix':
+        source = {
+            'algorithm': algorithm,
+            'distanceMatrixId': distance_matrix_id,
+            'parameters': parameters
+        }
+    elif source_type == 'algorithm_typing_data':
+        dataset = datasets_collection.find_one(
+            {
+            'project_Id': project_id,
+            'datasetId': dataset_id
+            }
+        )
 
-    workflow = workflows_collection.find_one({'_id': ObjectId(workflow_id)})
+        typing_data_id = dataset['typingDataId']
 
-    source = {
-        'algorithm': workflow['data']['algorithm'],
-        'distanceMatrixId': workflow['data']['distanceMatrixId'],
-        'parameters': workflow['data']['parameters']
-    } if source_type == 'algorithm_distance_matrix' else {
-        'algorithm': workflow['data']['algorithm'],
-        'typingDataId': workflow['data']['typingDataId'],
-        'parameters': workflow['data']['parameters']
-    } if source_type == 'algorithm_typing_data'
+        # Obtain the resource metadata with a repositoryId 's3'
+        resource = resource_type_collection.find_one(
+            {
+            'project_Id': project_id,
+            get_resource_id_attr_from_resource_type(resource_type): resource_id,
+            'repositoryId': 's3'
+            }
+        )
+
+        source = {
+            'algorithm': algorithm,
+            'typingDataId': typing_data_id,
+            'parameters': parameters
+        }
+    else:
+        print(f'Unknown source type: {source_type}')
+        return
 
     tree_metadata = {
         'treeId': tree_id,
@@ -61,19 +78,26 @@ def tree_handler(s3_output_path, project_id, dataset_id, tree_id, workflow_id, s
 
     tree_collection.insert_one(tree_metadata)
 
-    print(f'File uploaded to S3 and metadata created in the tree collection with treeId: {tree_id}')
-
-
-def distance_matrix_handler(s3_output_path, project_id, dataset_id, distance_matrix_id, workflow_id):
-    distance_matrix_collection = db['distance-matrices']
-
     workflows_collection.update_one(
         {'_id': ObjectId(workflow_id)},
         {'$set': {
-            'data.distanceMatrixId': distance_matrix_id
-        }})
+            'data.treeId': tree_id
+        }}
+    )
 
-    workflow = workflows_collection.find_one({'_id': ObjectId(workflow_id)})
+    print(f'File uploaded to S3 and metadata created in the tree collection with treeId: {tree_id}')
+
+
+def distance_matrix_handler(s3_output_path, project_id, dataset_id, workflow_id, distance_matrix_id, source_type, function):
+    distance_matrix_collection = db['distance-matrices']
+
+    if source_type == 'function':
+        source = {
+            'function': function
+        }
+    else:
+        print(f'Unknown source type: {source_type}')
+        return
 
     distance_matrix_metadata = {
         'projectId': project_id,
@@ -81,10 +105,8 @@ def distance_matrix_handler(s3_output_path, project_id, dataset_id, distance_mat
         'distanceMatrixId': distance_matrix_id,
         'repositoryId': 's3',
         'name': f'Distance Matrix {distance_matrix_id}',
-        'sourceType': 'function',
-        'source': {
-            'function': workflow['data']['function']
-        },
+        'sourceType': source_type,
+        'source': source,
         'repositorySpecificData': {
             'url': f'http://localhost:9444/{bucket_name}{s3_output_path}',
         }
@@ -92,26 +114,27 @@ def distance_matrix_handler(s3_output_path, project_id, dataset_id, distance_mat
 
     distance_matrix_collection.insert_one(distance_matrix_metadata)
 
+    workflows_collection.update_one(
+        {'_id': ObjectId(workflow_id)},
+        {'$set': {
+            'data.distanceMatrixId': distance_matrix_id
+        }}
+    )
+
     print(
         f'File uploaded to S3 and metadata created in the distance matrix collection with distanceMatrixId: {distance_matrix_id}')
-
-
-handler_map = {
-    "tree": tree_handler,
-    "distance-matrix": distance_matrix_handler,
-}
 
 resource_type_collection_map = {
     "tree": "trees",
     "distance-matrix": "distance-matrices",
 }
 
-
 def get_collection_from_resource_type(resource_type):
     return resource_type_collection_map[resource_type]
 
 
-def upload_file_to_s3(file_path, project_id, dataset_id, resource_id, resource_type, workflow_id, source_type):
+def upload_file_to_s3(file_path, project_id, dataset_id, workflow_id, resource_id, resource_type, source_type,
+                        algorithm, distance_matrix_id, parameters, function):
     # Generate a unique resource_id if not provided
     if not resource_id:
         resource_id = str(uuid.uuid4())
@@ -123,12 +146,20 @@ def upload_file_to_s3(file_path, project_id, dataset_id, resource_id, resource_t
     with open(file_path, 'rb') as file:
         s3.upload_fileobj(file, bucket_name, s3_output_path)
 
-    handler_map[resource_type](s3_output_path, project_id, dataset_id, resource_id, workflow_id, source_type)
-
+    if resource_type == "tree":
+        tree_id = resource_id
+        tree_handler(s3_output_path, project_id, dataset_id, workflow_id, tree_id, source_type, algorithm,
+                               distance_matrix_id, parameters)
+    elif resource_type == "distance-matrix":
+        distance_matrix_id = resource_id
+        distance_matrix_handler(s3_output_path, project_id, dataset_id, workflow_id, distance_matrix_id, source_type,
+                                    function)
+    else:
+        print(f'Unknown resource type: {resource_type}')
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
-        description='Upload a file to Amazon S3 and update a workflow in MongoDB.')
+        description='Upload a file to Amazon S3 and update a metadata in MongoDB.')
     parser.add_argument('--file-path', help='The file path', required=True)
     parser.add_argument('--project-id', help='The project id', required=True)
     parser.add_argument('--dataset-id', help='The dataset id', required=True)
@@ -138,7 +169,12 @@ if __name__ == '__main__':
         '--resource-id', help='The optional ID of the resource', default=None)
     parser.add_argument('--resource-type', help='The resource type', required=True)
     parser.add_argument('--source-type', help='The source type', required=False)
+    parser.add_argument('--algorithm', help='The algorithm', required=False)
+    parser.add_argument('--distance-matrix-id', help='The distance matrix id', required=False)
+    parser.add_argument('--parameters', help='The parameters of the algorithm', required=False)
+    parser.add_argument('--function', help='The function', required=False)
     args = parser.parse_args()
 
-    upload_file_to_s3(args.file_path, args.project_id, args.dataset_id, args.resource_id, args.resource_type,
-                      args.workflow_id, args.source_type)
+    upload_file_to_s3(args.file_path, args.project_id, args.dataset_id, args.workflow_id, args.resource_id,
+                        args.resource_type, args.source_type, args.algorithm, args.distance_matrix_id,
+                        args.parameters, args.function)


### PR DESCRIPTION
Added more command arguments to the tools, and also appropriately to the workflows that use them:
- added projectId, datasetId and workflowId to the downloader tool, in order to allow for proper validation (if project exists, if dataset exists, and the resource is actually a part of the project and dataset).
- added useful information for building the resource metadata, like sourceType and source information (for example, for the tree, added "algorithm", "distance-matrix-id")

Other tools still need to change to take certain command arguments for the metadata to have the actual source. TODO later.
